### PR TITLE
Switch to using the machine format for the logs

### DIFF
--- a/src/analyze/DartAnalyzeLogType.ts
+++ b/src/analyze/DartAnalyzeLogType.ts
@@ -1,22 +1,22 @@
 import { actionOptions } from "../utils/ActionOptions";
 import { FailOnEnum } from "../utils/FailOn";
 
-export enum DartAnalyzeLogTypeEnum{
+export enum DartAnalyzeLogTypeEnum {
   Info = 1,
   Warning = 2,
   Error = 3,
 }
 
-export type DartAnalyzeLogTypeKey = 'info'|'warning'|'error';
+export type DartAnalyzeLogTypeKey = 'INFO' | 'WARNING' | 'ERROR';
 
-export type LogKey = 'warning'|'error';
+export type LogKey = 'INFO' | 'WARNING' | 'ERROR';
 
 export class DartAnalyzeLogType {
   public static typeFromKey(key: DartAnalyzeLogTypeKey): DartAnalyzeLogTypeEnum {
-    switch(key) {
-      case 'error':
+    switch (key) {
+      case 'ERROR':
         return DartAnalyzeLogTypeEnum.Error;
-      case 'warning':
+      case 'WARNING':
         return DartAnalyzeLogTypeEnum.Warning;
       default:
         return DartAnalyzeLogTypeEnum.Info;
@@ -26,9 +26,11 @@ export class DartAnalyzeLogType {
   public static keyFromType(logType: DartAnalyzeLogTypeEnum): LogKey {
     switch (logType) {
       case DartAnalyzeLogTypeEnum.Error:
-        return 'error';
+        return 'ERROR';
+      case DartAnalyzeLogTypeEnum.Warning:
+        return 'WARNING';
       default:
-        return 'warning';
+        return 'INFO';
     }
   }
 

--- a/src/analyze/ParsedLine.ts
+++ b/src/analyze/ParsedLine.ts
@@ -1,6 +1,6 @@
 import { actionOptions } from "../utils/ActionOptions";
 import { FailOnEnum } from "../utils/FailOn";
-import { DartAnalyzeLogType, DartAnalyzeLogTypeEnum, DartAnalyzeLogTypeKey,} from "./DartAnalyzeLogType";
+import { DartAnalyzeLogType, DartAnalyzeLogTypeEnum, DartAnalyzeLogTypeKey, } from "./DartAnalyzeLogType";
 
 export interface ParsedLineInterface {
   file: string;
@@ -21,29 +21,29 @@ export class ParsedLine {
   readonly type: DartAnalyzeLogTypeEnum
   readonly originalLine: string;
 
-  constructor(params: {line: string, delimiter?: string}) {
-      this.originalLine = params.line;
-      const lineData = params.line.split(params?.delimiter?? '-');
-      this.type = DartAnalyzeLogType.typeFromKey(lineData[0].trim() as DartAnalyzeLogTypeKey);
-      const lints = lineData[1].trim().split(' at ');
-      const location = lints.pop()?.trim()!;
-      const lintMessage = lints.join(' at ').trim();
-      const [file, lineNumber, columnNumber] = location.split(':');
-      const lintName = lineData[2].replace(/[\W]+/g, '');
-      const lintNameLowerCase = lintName.toLowerCase();
-      let urls = [`https://dart.dev/tools/diagnostic-messages#${lintNameLowerCase}`];
-      if (lintName === lintNameLowerCase) {
-        urls = [`https://dart-lang.github.io/linter/lints/${lintNameLowerCase}.html`, ...urls];
-      }
-      this.urls = urls as [string] | [string, string];
-      this.file = file;
-      this.line = parseInt(lineNumber);
-      this.column = parseInt(columnNumber);
-      this.message = lintMessage;
+  constructor(params: { line: string, delimiter?: string }) {
+    this.originalLine = params.line;
+    const lineData = params.line.split(params?.delimiter ?? '|');
+    this.type = DartAnalyzeLogType.typeFromKey(lineData[0].trim() as DartAnalyzeLogTypeKey);
+    const lintMessage = lineData[7];
+    const file = lineData[3];
+    const lineNumber = lineData[4];
+    const columnNumber = lineData[5];
+    const lintName = lineData[2]
+    const lintNameLowerCase = lintName.toLowerCase();
+    let urls = [`https://dart.dev/tools/diagnostic-messages#${lintNameLowerCase}`];
+    if (lintName === lintNameLowerCase) {
+      urls = [`https://dart-lang.github.io/linter/lints/${lintNameLowerCase}.html`, ...urls];
+    }
+    this.urls = urls as [string] | [string, string];
+    this.file = file;
+    this.line = parseInt(lineNumber);
+    this.column = parseInt(columnNumber);
+    this.message = lintMessage;
   }
 
-  public get isFail():boolean {
-    if (actionOptions.failOn !== FailOnEnum.Nothing){
+  public get isFail(): boolean {
+    if (actionOptions.failOn !== FailOnEnum.Nothing) {
       if (this.type === DartAnalyzeLogTypeEnum.Error) {
         return true;
       }
@@ -61,7 +61,7 @@ export class ParsedLine {
   }
 
   public get emoji(): string {
-    switch(this.type) {
+    switch (this.type) {
       case DartAnalyzeLogTypeEnum.Error:
         return ':bangbang:';
       case DartAnalyzeLogTypeEnum.Warning:

--- a/src/analyze/analyze.ts
+++ b/src/analyze/analyze.ts
@@ -31,7 +31,7 @@ export async function analyze(params: { modifiedFiles: ModifiedFiles }): Promise
   const args = [actionOptions.workingDirectory];
 
   try {
-    await exec.exec('dart analyze', args, options);
+    await exec.exec('dart analyze --format machine', args, options);
   } catch (_) {
     // dart analyze sometimes fails
   }
@@ -41,7 +41,7 @@ export async function analyze(params: { modifiedFiles: ModifiedFiles }): Promise
   let infoCount = 0;
   const lines = outputs.trim().split(/\r?\n/);
   const errLines = errOutputs.trim().split(/\r?\n/);
-  const delimiter = '-';
+  const delimiter = '|';
 
   const parsedLines: ParsedLine[] = [];
 


### PR DESCRIPTION
This is now using the machine format for the result from dart analyze. It's a bit easier to parse than the human readable version.

I was having an issue where my 'info' logs weren't being accumulated, and weren't failing when I set the fail-on option to info so I assumed there might have been some change in the format of the logs.

I haven't been able to test this locally either due to the same issue as with the other PR. If you know how I can resolve that (I wasn't planning on adding npm to my flutter project to test it) I can make sure it works

Should fix #5 